### PR TITLE
Add Nix package for GraphQL engine

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
     {
       packages = {
         graphql-parser = pkgs.haskell.packages.${pkgs.ghcName}.graphql-parser;
+        graphql-engine = pkgs.haskell.packages.${pkgs.ghcName}.graphql-engine;
       };
 
       formatter = pkgs.nixpkgs-fmt;

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -15,7 +15,9 @@ import nixpkgs {
     (import ./overlays/graphql-parser.nix)
     (import ./overlays/resource-pool.nix)
     (import ./overlays/dc-api.nix)
+    (import ./overlays/server-libs.nix)
     (import ./overlays/pg-client-hs.nix)
+    (import ./overlays/graphql-engine.nix)
     (import ./overlays/aeson-ordered.nix)
   ];
 }

--- a/nix/overlays/graphql-engine.nix
+++ b/nix/overlays/graphql-engine.nix
@@ -1,0 +1,16 @@
+final: prev: {
+  haskell = prev.haskell // {
+    packages = prev.haskell.packages // {
+      ${prev.ghcName} = prev.haskell.packages.${prev.ghcName}.override (old: {
+        overrides = prev.lib.composeExtensions
+          (old.overrides or (_: _: { }))
+          (hfinal: hprev: {
+            # Tests are disabled as they require extra setup
+            graphql-engine = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "graphql-engine" ../../server { }
+            );
+          });
+      });
+    };
+  };
+}

--- a/nix/overlays/server-libs.nix
+++ b/nix/overlays/server-libs.nix
@@ -1,0 +1,58 @@
+final: prev: {
+  haskell = prev.haskell // {
+    packages = prev.haskell.packages // {
+      ${prev.ghcName} = prev.haskell.packages.${prev.ghcName}.override (old: {
+        overrides = prev.lib.composeExtensions
+          (old.overrides or (_: _: { }))
+          (hfinal: hprev: {
+            arrows-extra = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "arrows-extra" ../../server/lib/arrows-extra { }
+            );
+            ci-info = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "ci-info" ../../server/lib/ci-info { }
+            );
+            ekg-json = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "ekg-json" ../../server/lib/ekg-json { }
+            );
+            ekg-prometheus = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "ekg-prometheus" ../../server/lib/ekg-prometheus { }
+            );
+            hasura-base = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "hasura-base" ../../server/lib/hasura-base { }
+            );
+            hasura-error-message = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "hasura-error-message" ../../server/lib/hasura-error-message { }
+            );
+            hasura-extras = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "hasura-extras" ../../server/lib/hasura-extras { }
+            );
+            hasura-json-encoding = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "hasura-json-encoding" ../../server/lib/hasura-json-encoding { }
+            );
+            hasura-prelude = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "hasura-prelude" ../../server/lib/hasura-prelude { }
+            );
+            incremental = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "incremental" ../../server/lib/incremental { }
+            );
+            schema-parsers = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "schema-parsers" ../../server/lib/schema-parsers { }
+            );
+            kriti-lang = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callHackage "kriti-lang" "0.3.1" { }
+            );
+            libdeflate-hs = prev.haskell.lib.dontCheck (
+              final.haskell.packages.${prev.ghcName}.callCabal2nix "libdeflate-hs"
+                (final.fetchFromGitHub {
+                  owner = "hasura";
+                  repo = "libdeflate-hs";
+                  rev = "e6f020a1a24d07516d753fbb6f30758774f76372";
+                  sha256 = "14nabiar6i873x8z1b6higd20ld7441zzywbdc64ih140f6qdi2c";
+                })
+                { }
+            );
+          });
+      });
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- package Hasura server and dependencies in `server-libs.nix`
- expose `graphql-engine` package in flake outputs
- include `kriti-lang` dependency in server library overlay

## Testing
- `nix --extra-experimental-features 'nix-command flakes' build .#graphql-engine --dry-run` *(fails: command not found: nix)*
- `sh <(curl -L https://nixos.org/nix/install) --no-daemon` *(fails: the build users group 'nixbld' has no members)*
